### PR TITLE
fix ffw rule deletion

### DIFF
--- a/pkg/firewall/plugin.go
+++ b/pkg/firewall/plugin.go
@@ -348,7 +348,7 @@ func (p *Plugin) execDelete(conf *Config, prevResult *current.Result) error {
 					continue
 				}
 
-				if ffwExsists, err = utils.IsChainExists(addr.Version, p.natTableName, ffwChain); err != nil {
+				if ffwExsists, err = utils.IsChainExists(addr.Version, p.filterTableName, ffwChain); err != nil {
 					return fmt.Errorf(
 						"error checking ipv%s firewall container chain %s info: %s",
 						v, ffwChain, err,


### PR DESCRIPTION
Hi,

I believe there's a bug in `execDelete` which prevents it from removing the filter-forward chain for the container id.

With v1.0.9 after removing a pod with podman, the chains are still in my ruleset:
```
table ip _filter {
        chain _forward {
                type filter hook forward priority 0; policy accept;
                jump cni-ffw-8726fd92cb82f541940f26a
                jump cni-ffw-469fc695dc03346d8d7865c
        }

        chain cni-ffw-469fc695dc03346d8d7865c {
                oifname "cni-podman0" ip daddr 20.88.0.20 ct state established,related counter packets 0 bytes 0 accept
                iifname "cni-podman0" ip saddr 20.88.0.20 counter packets 0 bytes 0 accept
                iifname "cni-podman0" oifname "cni-podman0" counter packets 0 bytes 0 accept
        }

        chain cni-ffw-8726fd92cb82f541940f26a {
                oifname "cni-podman0" ip daddr 20.88.0.21 ct state established,related counter packets 0 bytes 0 accept
                iifname "cni-podman0" ip saddr 20.88.0.21 counter packets 0 bytes 0 accept
                iifname "cni-podman0" oifname "cni-podman0" counter packets 0 bytes 0 accept
        }
}
```

but the rules under the nat table, postrouting chain are correctly removed.

As far as I can tell, [this check](https://github.com/greenpau/cni-plugins/blob/main/pkg/firewall/plugin.go#L351) is wrong, the `ffwChain` is in the filter table, not the nat table. This PR fixes this.

 I've verified on my server that it works correctly now, but let me know if I'm misunderstanding something