### PR TITLE
bind port mappings to HostIP, if specified

### DIFF
--- a/pkg/utils/dest_nat.go
+++ b/pkg/utils/dest_nat.go
@@ -62,6 +62,11 @@ func AddDestinationNatRules(opts map[string]interface{}) error {
 		Data:     EncodeInterfaceName(bridgeIntfName),
 	})
 
+	// match host IP, if specified
+	if hostIP := net.ParseIP(pm.HostIP); hostIP != nil {
+		r.Exprs = append(r.Exprs, IPDaddrMatch(v, hostIP)...)
+	}
+
 	// match port
 
 	r.Exprs = append(r.Exprs, &expr.Meta{


### PR DESCRIPTION
When using `podman run -p 10.25.0.1:8443:8443` before this commit, port 8443 would be reachable on all interfaces, as if one used `podman run -p 8443:8443`.

This is obviously not great for security — I’m using podman on an internet router with multiple network interfaces and really want to have my container ports reachable only internally, not also on the public internet :)